### PR TITLE
Format apr column to two decimal places

### DIFF
--- a/components/capital/capital-info-panel.tsx
+++ b/components/capital/capital-info-panel.tsx
@@ -12,6 +12,19 @@ import type { AssetSymbol } from "@/context/CapitalPageContext";
 import { getAssetsForNetwork, type NetworkEnvironment } from "./constants/asset-config";
 import { getContractAddress } from "@/config/networks";
 
+// Helper function to format APR values to 2 decimal places
+const formatAPR = (aprValue: string): string => {
+  // If it's a percentage, extract the number and reformat to 2 decimal places
+  if (aprValue.includes('%')) {
+    const numericValue = parseFloat(aprValue.replace('%', ''));
+    if (!isNaN(numericValue)) {
+      return `${numericValue.toFixed(2)}%`;
+    }
+  }
+  // Return as-is for non-numeric values like 'N/A', 'Coming Soon'
+  return aprValue;
+};
+
 export function CapitalInfoPanel() {
   const {
     userAddress,
@@ -143,7 +156,7 @@ export function CapitalInfoPanel() {
                     <div className={`text-center text-sm font-semibold truncate ${
                       asset.disabled ? 'text-gray-500' : 'text-white'
                     }`}>
-                      {asset.apy}
+                      {formatAPR(asset.apy)}
                     </div>
 
                     {/* Total Staked */}


### PR DESCRIPTION
Format APR values in the Capital Info panel to consistently display two decimal places for improved readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-acec5d8d-bda2-458c-af79-3dc4ff5dd16c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-acec5d8d-bda2-458c-af79-3dc4ff5dd16c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

