### PR TITLE
Investigate testnet badge display logic

### DIFF
--- a/components/root-layout.tsx
+++ b/components/root-layout.tsx
@@ -53,7 +53,7 @@ export function RootLayoutContent({
 }) {
   // const pathname = usePathname()
   const chainId = useChainId()
-  const isTestnet = chainId === 421614 || chainId === 8453 || chainId === 11155111 // Arbitrum Sepolia or Base Sepolia or Sepolia
+  const isTestnet = chainId === 421614 || chainId === 11155111 // Arbitrum Sepolia or Sepolia
   // const pageInfo = getPageInfo(pathname)
 
   return (


### PR DESCRIPTION
Remove Base (chain ID 8453) from the `isTestnet` check to prevent the incorrect "Connected to Testnet" badge display on Base mainnet.

The previous logic incorrectly identified Base mainnet as a testnet, causing the "Connected to Testnet" badge to be shown to users on Base mainnet. This change ensures the badge only appears for actual testnets.

---
<a href="https://cursor.com/background-agent?bcId=bc-debc5e0e-30a8-43cc-b00f-125b00a59abf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-debc5e0e-30a8-43cc-b00f-125b00a59abf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

