### PR TITLE
Update base builder names from subgraph

### DIFF
--- a/app/api/builders/route.ts
+++ b/app/api/builders/route.ts
@@ -19,9 +19,24 @@ interface MorlordBuilder {
   [key: string]: string | number;
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    // Fetch data from the external API
+    const { searchParams } = new URL(request.url);
+    const network = searchParams.get('network');
+
+    // For Base network, we don't use this API route anymore since we get names directly from subgraph
+    // This route is now primarily used for Arbitrum network or as fallback
+    if (network === 'base') {
+      return NextResponse.json([], {
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        },
+      });
+    }
+
+    // For Arbitrum or other networks, fetch from morlord API
     const response = await fetch('https://morlord.com/data/builders.json', {
       // Adding a short timeout to fail fast if the service is down
       signal: AbortSignal.timeout(5000)

--- a/app/hooks/useBaseSubgraphBuilders.ts
+++ b/app/hooks/useBaseSubgraphBuilders.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { getClientForNetwork } from '@/lib/apollo-client';
+import { GET_BUILDERS_PROJECT_NAMES_BASE } from '@/lib/graphql/builders-queries';
+
+/**
+ * Hook to fetch builder names directly from Base subgraph
+ * This replaces the morlord API for Base network
+ */
+export const useBaseSubgraphBuilders = () => {
+  return useQuery<string[]>({
+    queryKey: ['baseSubgraphBuilders'],
+    queryFn: async () => {
+      try {
+        const client = getClientForNetwork('Base');
+        if (!client) {
+          throw new Error('Could not get Apollo client for Base network');
+        }
+
+        const response = await client.query<{ buildersProjects: { name: string }[] }>({
+          query: GET_BUILDERS_PROJECT_NAMES_BASE,
+          fetchPolicy: 'no-cache',
+        });
+
+        // Extract just the names from the response
+        const builderNames = response.data.buildersProjects.map(project => project.name);
+
+        return builderNames;
+      } catch (error) {
+        console.error('[useBaseSubgraphBuilders] Error fetching builders from Base subgraph:', error);
+        // Return empty array to avoid breaking the app
+        return [];
+      }
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    retry: 3, // Retry 3 times if the request fails
+  });
+};

--- a/lib/graphql/builders-queries.ts
+++ b/lib/graphql/builders-queries.ts
@@ -415,4 +415,13 @@ export const GET_BUILDER_SUBNET_BY_ID = gql`
       __typename
     }
   }
+`;
+
+// Query to get just builder names from Base subgraph
+export const GET_BUILDERS_PROJECT_NAMES_BASE = gql`
+  query getBuildersProjectNamesBase {
+    buildersProjects(first: 1000, skip: 0) {
+      name
+    }
+  }
 `; 


### PR DESCRIPTION
Switch Base network builder name retrieval to use a dedicated subgraph query instead of the Morlord API.

This change fulfills the request to use the specified Base subgraph for builder names, enhancing data sourcing for the `/builders` section by leveraging a more direct and network-specific data source.

---
<a href="https://cursor.com/background-agent?bcId=bc-78362686-335b-4418-b876-770d9305fc08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-78362686-335b-4418-b876-770d9305fc08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

