### PR TITLE
Apply arbitrum builder name subgraph query

### DIFF
--- a/lib/graphql/builders-queries.ts
+++ b/lib/graphql/builders-queries.ts
@@ -424,4 +424,13 @@ export const GET_BUILDERS_PROJECT_NAMES_BASE = gql`
       name
     }
   }
+`;
+
+// Query to get just builder names from Arbitrum subgraph
+export const GET_BUILDERS_PROJECT_NAMES_ARBITRUM = gql`
+  query getBuildersProjectNamesArbitrum {
+    buildersProjects(first: 1000, skip: 0) {
+      name
+    }
+  }
 `; 


### PR DESCRIPTION
Add direct Arbitrum subgraph query for builder names, mirroring the existing Base implementation, to fetch builder names more efficiently.

---
<a href="https://cursor.com/background-agent?bcId=bc-6937f10c-a428-4ef4-a7e9-ee28d0396f56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6937f10c-a428-4ef4-a7e9-ee28d0396f56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

