### PR TITLE
Fix arbitrumNames type error in builders service

### DIFF
--- a/app/services/buildersService.ts
+++ b/app/services/buildersService.ts
@@ -178,7 +178,7 @@ export const fetchBuildersAPI = async (
       
       // Use separate builder names for Base and Arbitrum networks
       const baseNames = Array.isArray(baseBuilderNames) ? baseBuilderNames : [];
-      const arbitrumNames = Array.isArray(arbitrumBuilderNames) ? arbitrumNames : [];
+      const arbitrumNames = Array.isArray(arbitrumBuilderNames) ? arbitrumBuilderNames : [];
 
       // Combine with Supabase builders for complete coverage
       const supabaseNames = supabaseBuilders.map(b => b.name);


### PR DESCRIPTION
Fix a TypeScript error by correcting a typo in the `arbitrumNames` initializer.

The `arbitrumNames` variable was incorrectly referencing itself in its own initializer, leading to a TypeScript error about implicit `any` type. This change corrects the reference to `arbitrumBuilderNames`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c403717-4dbb-4280-8323-4830d1adb1fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c403717-4dbb-4280-8323-4830d1adb1fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

