### PR TITLE
Add unique subnet count metric

### DIFF
--- a/context/builders-context.tsx
+++ b/context/builders-context.tsx
@@ -117,10 +117,19 @@ export function BuildersProvider({ children }: { children: ReactNode }) {
   }, [builders]);
 
   const totalMetrics = useMemo(() => {
+    // Calculate unique subnet count across all networks
+    const allSubnetNames = new Set<string>();
+    builders.forEach(builder => {
+      if (builder.name) {
+        allSubnetNames.add(builder.name);
+      }
+    });
+
     return {
       totalBuilders: builders.length,
       totalStaked: builders.reduce((acc, builder) => acc + (builder.totalStaked || 0), 0),
       totalStaking: builders.reduce((acc, builder) => acc + (builder.stakingCount || 0), 0),
+      uniqueSubnetCount: allSubnetNames.size,
     };
   }, [builders]);
   


### PR DESCRIPTION
Add a "Unique:" subnet count metric to the builders table on the `/builders` page, deduplicating subnets by their names.

---
<a href="https://cursor.com/background-agent?bcId=bc-98e07d69-1bde-40af-bca4-a88d5204fcfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-98e07d69-1bde-40af-bca4-a88d5204fcfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

