### PR TITLE
fix compute page fake subnet data and staking allowance races

### DIFF
--- a/app/builders/[slug]/page.tsx
+++ b/app/builders/[slug]/page.tsx
@@ -792,13 +792,18 @@ export default function BuilderPage() {
 		}
 
 		// Force a fresh check for approval before proceeding
-		const currentlyNeedsApproval = stakeAmount
-			? await checkAndUpdateApprovalNeeded(stakeAmount)
-			: false;
+		const approvalStatus = stakeAmount
+			? checkAndUpdateApprovalNeeded(stakeAmount)
+			: null;
+
+		if (approvalStatus === null) {
+			showAlert(`Still checking ${tokenSymbol} allowance. Please wait a moment and try again.`);
+			return;
+		}
 
 		// Already on correct network, handle approval or staking
 		if (
-			(currentlyNeedsApproval || needsApproval) &&
+			(approvalStatus || needsApproval) &&
 			stakeAmount &&
 			parseFloat(stakeAmount) > 0
 		) {
@@ -808,7 +813,7 @@ export default function BuilderPage() {
 		} else {
 			console.warn("Neither approval nor staking conditions met:", {
 				needsApproval,
-				currentlyNeedsApproval,
+				approvalStatus,
 				stakeAmount,
 				parsed: parseFloat(stakeAmount || "0"),
 			});

--- a/components/staking/stake-modal.tsx
+++ b/components/staking/stake-modal.tsx
@@ -126,6 +126,7 @@ export function StakeModal({
     isCorrectNetwork,
     tokenSymbol,
     needsApproval,
+    isLoadingData,
     isSubmitting,
     handleApprove,
     handleStake,
@@ -155,7 +156,7 @@ export function StakeModal({
 
   // Check if the stake amount is valid (following page.tsx validation pattern)
   const isValidForSubmission = useMemo(() => {
-    if (!stakeAmount || !effectiveTokenBalance) return false;
+    if (!stakeAmount || !effectiveTokenBalance || isLoadingData) return false;
     
     const amount = parseFloat(stakeAmount);
     if (isNaN(amount) || amount <= 0) return false;
@@ -167,7 +168,7 @@ export function StakeModal({
     if (selectedBuilder?.minDeposit && amount < selectedBuilder.minDeposit) return false;
     
     return true;
-  }, [stakeAmount, effectiveTokenBalance, selectedBuilder]);
+  }, [stakeAmount, effectiveTokenBalance, selectedBuilder, isLoadingData]);
 
   // Warning logic (following page.tsx pattern)
   const showWarning = useMemo(() => {
@@ -177,11 +178,12 @@ export function StakeModal({
     const amount = parseFloat(stakeAmount);
     if (isNaN(amount) || amount <= 0) return true;
     
-    // Show warning if on wrong network OR insufficient balance OR needs approval
+    // Show warning if on wrong network OR insufficient balance OR needs approval OR allowance still loading
     return chainId !== targetNetworkInfo.chainId ||
+           isLoadingData ||
            (needsApproval && amount > 0) ||
            (effectiveTokenBalance && amount > parseFloat(formatEther(effectiveTokenBalance)));
-  }, [stakeAmount, chainId, targetNetworkInfo.chainId, needsApproval, effectiveTokenBalance]);
+  }, [stakeAmount, chainId, targetNetworkInfo.chainId, needsApproval, effectiveTokenBalance, isLoadingData]);
 
   const warningMessage = useMemo(() => {
     // Show message if input is empty
@@ -236,6 +238,10 @@ export function StakeModal({
     if (chainId !== targetNetworkInfo.chainId) {
       return `Please switch to ${targetNetworkInfo.networkName} network to stake`;
     }
+
+    if (isLoadingData) {
+      return `Checking ${tokenSymbol} allowance...`;
+    }
     
     // Finally check approval
     if (needsApproval && amount > 0) {
@@ -243,14 +249,14 @@ export function StakeModal({
     }
     
     return "";
-  }, [stakeAmount, chainId, targetNetworkInfo, needsApproval, tokenSymbol, effectiveTokenBalance, selectedBuilder, isTestnet]);
+  }, [stakeAmount, chainId, targetNetworkInfo, needsApproval, tokenSymbol, effectiveTokenBalance, selectedBuilder, isTestnet, isLoadingData]);
 
-  // Check approval status when amount changes
+  // Check approval status when amount changes (wait until allowance data is loaded)
   useEffect(() => {
-    if (stakeAmount && parseFloat(stakeAmount) > 0) {
+    if (stakeAmount && parseFloat(stakeAmount) > 0 && !isLoadingData) {
       checkAndUpdateApprovalNeeded(stakeAmount);
     }
-  }, [stakeAmount, checkAndUpdateApprovalNeeded]);
+  }, [stakeAmount, checkAndUpdateApprovalNeeded, isLoadingData]);
 
   // Reset form state when modal opens or closes
   useEffect(() => {
@@ -290,9 +296,14 @@ export function StakeModal({
       }
 
       // Only proceed with approval/staking if we're on the correct network
-      const currentlyNeedsApproval = stakeAmount ? await checkAndUpdateApprovalNeeded(stakeAmount) : false;
+      const approvalStatus = stakeAmount ? checkAndUpdateApprovalNeeded(stakeAmount) : null;
 
-      if ((currentlyNeedsApproval || needsApproval) && stakeAmount && parseFloat(stakeAmount) > 0) {
+      if (approvalStatus === null) {
+        setFormError(`Still checking ${tokenSymbol} allowance. Please wait a moment.`);
+        return;
+      }
+
+      if ((approvalStatus || needsApproval) && stakeAmount && parseFloat(stakeAmount) > 0) {
         await handleApprove(stakeAmount);
       } else if (stakeAmount && parseFloat(stakeAmount) > 0) {
         await handleStake(stakeAmount);
@@ -399,11 +410,14 @@ export function StakeModal({
               }
               disabled={
                 isSubmitting || 
-                !isValidForSubmission
+                !isValidForSubmission ||
+                isLoadingData
               }
             >
               {isSubmitting ? (
                 "Processing..."
+              ) : isLoadingData ? (
+                "Checking allowance..."
               ) : chainId !== targetNetworkInfo.chainId ? (
                 `Switch to ${targetNetworkInfo.networkName}`
               ) : (needsApproval && stakeAmount && parseFloat(stakeAmount) > 0) ? (

--- a/context/compute-context.tsx
+++ b/context/compute-context.tsx
@@ -326,90 +326,34 @@ export function ComputeProvider({ children }: { children: ReactNode }) {
         // console.log(`API call attempt ${retryCount + 1}:`, data);
       }
       
+      if (data.errors?.length) {
+        throw new Error(data.errors.map((e: { message: string }) => e.message).join('; '));
+      }
+
+      if (!data.data) {
+        throw new Error('Subgraph returned no data');
+      }
+
       // Set counters if available
-      if (data.data && data.data.counters) {
-        // console.log('Setting counters from API:', data.data.counters);
+      if (data.data.counters) {
         setCounters(data.data.counters);
       } else {
-        // console.log('Using fallback counter data');
-        // Fallback counter
-        setCounters([{ id: "0x00000000", totalSubnets: "2", __typename: "Counter" }]);
+        setCounters([{
+          id: "0x00000000",
+          totalSubnets: String(data.data.subnets?.length ?? 0),
+          __typename: "Counter"
+        }]);
       }
-      
-      // If API returns empty subnets array or there's any error, use fallback data
-      const shouldUseFallbackData = !data.data || !data.data.subnets || data.data.subnets.length === 0;
-      
-      if (shouldUseFallbackData) {
-        // console.log('Using fallback subnet data since API returned empty results');
-        
-        // Hard-coded fallback data
-        const fallbackSubnets = [
-          {
-            "id": "0x9ef62b6ce7dc1083b53a80d592cf021a21a03e20",
-            "fee": "9000000000000000000000000", // 90%
-            "name": "GenAscend",
-            "owner": "0x8b59ec5da5e5ce83abb3bd9079472f7b25666302",
-            "totalStaked": "72950000000000000000",
-            "totalClaimed": "0",
-            "deregistrationOpensAt": "1769230800",
-            "__typename": "Subnet"
-          },
-          {
-            "id": "0xa653ba99734766787d1f2dc068a67a27752935b6",
-            "fee": "9000000000000000000000000", // 90%
-            "name": "Titan.io",
-            "owner": "0xd6c8c7ebc21ec6cde34e845c9186d4e14597d847",
-            "totalStaked": "120000000000000000000",
-            "totalClaimed": "0",
-            "deregistrationOpensAt": "1770703200",
-            "__typename": "Subnet"
-          }
-        ];
-        
-        // console.log('Setting fallback subnets:', fallbackSubnets);
-        setRawSubnets(fallbackSubnets);
-      } else if (data.data && data.data.subnets) {
-        // console.log('Setting subnets from API:', data.data.subnets);
-        setRawSubnets(data.data.subnets);
-      }
-      
-      if (data.data && data.data.subnetUsers) {
-        setRawSubnetUsers(data.data.subnetUsers);
-      }
-      
+
+      setRawSubnets(data.data.subnets ?? []);
+      setRawSubnetUsers(data.data.subnetUsers ?? []);
       setError(null);
     } catch (err) {
       console.error('Error fetching compute data:', err);
       setError(err instanceof Error ? err : new Error('Failed to fetch compute data'));
-      
-      // Fallback data for development/testing
-      const fallbackSubnets = [
-        {
-          "id": "0x9ef62b6ce7dc1083b53a80d592cf021a21a03e20",
-          "fee": "9000000000000000000000000", // 90%
-          "name": "GenAscend",
-          "owner": "0x8b59ec5da5e5ce83abb3bd9079472f7b25666302",
-          "totalStaked": "72950000000000000000",
-          "totalClaimed": "0",
-          "deregistrationOpensAt": "1769230800",
-          "__typename": "Subnet"
-        },
-        {
-          "id": "0xa653ba99734766787d1f2dc068a67a27752935b6",
-          "fee": "9000000000000000000000000", // 90%
-          "name": "Titan.io",
-          "owner": "0xd6c8c7ebc21ec6cde34e845c9186d4e14597d847",
-          "totalStaked": "120000000000000000000",
-          "totalClaimed": "0",
-          "deregistrationOpensAt": "1770703200",
-          "__typename": "Subnet"
-        }
-      ];
-      
-      setRawSubnets(fallbackSubnets);
-      
-      // Set fallback counters as well
-      setCounters([{ id: "0x00000000", totalSubnets: "2", __typename: "Counter" }]);
+      setRawSubnets([]);
+      setRawSubnetUsers([]);
+      setCounters([]);
     } finally {
       setIsLoading(false);
     }

--- a/hooks/use-staking-data.ts
+++ b/hooks/use-staking-data.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { fetchGraphQL, getEndpointForNetwork } from "@/app/graphql/client";
 import { BuildersGraphQLResponse, ComputeGraphQLResponse, StakingEntry, BuildersUser, SubnetUser, BuildersProject } from "@/app/graphql/types";
 import { GET_BUILDERS_PROJECT_BY_NAME, GET_BUILDERS_PROJECT_BY_NAME_V1, GET_BUILDERS_PROJECT_USERS, GET_BUILDER_SUBNET_BY_NAME, GET_BUILDER_SUBNET_USERS } from "@/app/graphql/queries/builders";
@@ -181,6 +181,7 @@ export function useStakingData({
   
   // Cache for storing fetched pages
   const [cachedPages, setCachedPages] = useState<Record<number, StakingEntry[]>>({});
+  const fetchGenerationRef = useRef(0);
   
   // Default formatter functions
   const defaultFormatAddress = (address: string): string => {
@@ -315,6 +316,9 @@ export function useStakingData({
 
   // Fetch data
   const fetchData = useCallback(async () => {
+    const generation = ++fetchGenerationRef.current;
+    const isCurrentRequest = () => generation === fetchGenerationRef.current;
+
     console.log('[useStakingData] fetchData CALLED. Internal id before any checks:', id, 'projectName:', projectName, 'currentPage:', pagination.currentPage);
     // We should set loading to true on initial load, even if we're already loading
     // This fixes the issue where tables are stuck in loading state
@@ -437,7 +441,10 @@ export function useStakingData({
             // Background prefetch the second page if there are more pages
             if (totalPages > 1 && pagination.currentPage === 1) {
               console.log(`[useStakingData] Background prefetching page 2 data`);
+              const prefetchGeneration = generation;
+              const prefetchProjectId = projectIdToUse;
               setTimeout(() => {
+                if (!isCurrentRequest()) return;
                 fetchGraphQL<BuildersGraphQLResponse>(
                   endpoint,
                   queryFunction || "getBuildersProjectUsers",
@@ -445,11 +452,12 @@ export function useStakingData({
                   {
                     first: pagination.pageSize,
                     skip: pagination.pageSize, // Skip first page
-                    buildersProjectId: projectIdToUse,
+                    buildersProjectId: prefetchProjectId,
                     orderBy: 'staked',
                     orderDirection: 'desc'
                   }
                 ).then(nextPageResponse => {
+                  if (!isCurrentRequest()) return;
                   if (nextPageResponse.data?.buildersUsers) {
                     // Format and cache the next page
                     const formattedNextPageEntries = (nextPageResponse.data.buildersUsers?.items || []).map(user => {
@@ -528,6 +536,8 @@ export function useStakingData({
         
         console.log('[useStakingData] Formatted compute entries:', formattedEntries);
         
+        if (!isCurrentRequest()) return;
+
         // Only update cache and state if we have data and we're still on the same page
         setCachedPages(prev => ({
           ...prev,
@@ -1035,6 +1045,8 @@ export function useStakingData({
             // Process current page
             const currentPageEntries = formatAndFilterEntries(currentPageUsers, 'Current Page');
             
+            if (!isCurrentRequest()) return;
+
             // Update current page in cache and state
             setCachedPages(prev => ({
               ...prev,
@@ -1046,6 +1058,8 @@ export function useStakingData({
             if (pagination.currentPage === 1 && nextPageUsers.length > 0) {
               const nextPageEntries = formatAndFilterEntries(nextPageUsers, 'Next Page');
               
+              if (!isCurrentRequest()) return;
+
               // Cache next page
               setCachedPages(prev => ({
                 ...prev,

--- a/hooks/useStakingContractInteractions.ts
+++ b/hooks/useStakingContractInteractions.ts
@@ -606,19 +606,10 @@ export const useStakingContractInteractions = ({
         return false;
       }
       
-      // If no allowance data yet, don't assume approval is needed - wait for data to load
-      // This prevents false positives when user types a number before allowance loads
+      // If allowance data is not ready yet, caller must wait before staking
       if (allowance === undefined || !tokenAddress || !contractAddress) {
-        const missingData = [];
-        if (allowance === undefined) missingData.push("allowance");
-        if (!tokenAddress) missingData.push("tokenAddress");
-        if (!contractAddress) missingData.push("contractAddress");
-        
-        console.log(`Waiting for data: ${missingData.join(", ")}. Chain: ${networkChainId}, isTestnet: ${isTestnet}. Not assuming approval needed.`);
-        
-        // Don't set needsApproval to true when data is missing - wait for it to load
-        // This prevents the button from switching to "Approve" prematurely
-        return false; // Return false to indicate we're waiting, not that approval is needed
+        console.log(`Allowance check skipped, data still loading. Chain: ${networkChainId}, isTestnet: ${isTestnet}`);
+        return null;
       }
       
       const parsedAmount = parseEther(stakeAmount);
@@ -643,9 +634,8 @@ export const useStakingContractInteractions = ({
       return approvalNeeded;
     } catch (error) {
       console.error("Error checking approval:", error);
-      // On error, don't assume approval is needed - let the user try staking
-      // The contract will reject if approval is actually needed
-      return false;
+      setNeedsApproval(true);
+      return true;
     }
   }, [allowance, tokenAddress, contractAddress, networkChainId, isTestnet]);
 
@@ -729,6 +719,18 @@ export const useStakingContractInteractions = ({
         toast.error(`Insufficient balance. You have ${formatEther(userBalance)} ${tokenSymbol}.`);
         return false;
       }
+
+      if (allowance === undefined) {
+        toast.error(`Still checking ${tokenSymbol} allowance. Please wait a moment and try again.`);
+        return false;
+      }
+
+      const currentAllowance = allowance || BigInt(0);
+      if (currentAllowance < parsedAmount) {
+        setNeedsApproval(true);
+        toast.error(`Approve ${tokenSymbol} spending before staking.`);
+        return false;
+      }
       
       // BuildersV4 uses deposit() like mainnet, so we can unify the logic
       const networkName = isTestnet ? 'Base Sepolia' : 
@@ -758,7 +760,7 @@ export const useStakingContractInteractions = ({
       toast.error(`Failed to stake: ${error instanceof Error ? error.message : "Unknown error"}`);
       return false;
     }
-  }, [connectedAddress, isCorrectNetwork, contractAddress, subnetId, tokenBalance, networkChainId, isTestnet, tokenSymbol, writeStake, getChainById, lockPeriodInSeconds]);
+  }, [connectedAddress, isCorrectNetwork, contractAddress, subnetId, tokenBalance, allowance, networkChainId, isTestnet, tokenSymbol, writeStake, getChainById, lockPeriodInSeconds]);
 
   // Handle withdraw
   const handleWithdraw = useCallback(async (amount: string) => {


### PR DESCRIPTION
hey team, its mooncitydev. checked the codebase and found a few things that looked worth fixing.

first one is on the compute page. when the arbitrum subgraph fails or comes back empty, compute-context was injecting hardcoded genascend and titan.io subnets and calling setError(null). so during an outage users would see fake staking data that looks totally real. now it shows empty state with an actual error instead.

second, stake-modal was not waiting for allowance to load before letting users hit stake. builders slug page already had isLoadingData checks but the modal did not. handleStake now also refuses to deposit if allowance is missing or too low, so you dont waste gas on a revert.

third, use-staking-data had a background prefetch that could cache page 2 for the wrong builder if you switched subnets quickly. added a fetch generation guard so stale responses get ignored.

cheers